### PR TITLE
Fix top-level await load failure on Harper v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harperdb/status-check",
   "type": "module",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Harper component for checking the status of the HarperDB instance.",
   "license": "Apache-2.0"
 }

--- a/resources.js
+++ b/resources.js
@@ -3,10 +3,12 @@ const DEFAULT_200_MSG = "Status endpoint is reporting for duty.";
 const DEFAULT_404_MSG = "Status endpoint is reporting downtime.";
 
 if (server.workerIndex == 0) {
-  let record = await hdb_status.get(1);
-  if (!record) {
-    await hdb_status.put({ id: 1, status: 200, message: DEFAULT_200_MSG });
-  }
+  (async () => {
+    let record = await hdb_status.get(1);
+    if (!record) {
+      await hdb_status.put({ id: 1, status: 200, message: DEFAULT_200_MSG });
+    }
+  })();
 }
 
 export class status extends Resource {


### PR DESCRIPTION
## Summary
- Wrap the worker-0 startup seeding block in an async IIFE so the component no longer relies on **top-level `await`**, which fails to load under Harper v5.

## Background
On a freshly deployed Harper v5 cluster, loading `@harperdb/status-check` v1.0.2 fails with:

```
ResourceLoadError: Failed to load resource module .../status-check/resources.js:
await is only valid in async functions and the top level bodies of modules
```

Harper v5's `jsLoader` tries to load each component as **CommonJS first**, falling back to ESM only when the parse error looks like ESM syntax (it matches on `import` / `export` / `Cannot use import statement` / `Unexpected token`). Our top-level `await` in the seeding block throws a `SyntaxError` whose message contains none of those tokens, so the loader rethrows instead of retrying as ESM. (The parser hits the `await` before reaching `export class status`, so the recognized `export` error never surfaces.)

## Fix
Moving the seeding logic into an async IIFE removes the top-level `await`. The CJS parse then fails on the `export` statement instead — which the loader *does* recognize — so it correctly falls back to ESM and the component loads.

This is a behavior-preserving change: the seeding still runs once on worker 0 at startup.

## Test plan
- [ ] Deploy this branch as a component on a Harper v5 instance and confirm it loads without `ResourceLoadError`.
- [ ] `GET /status` returns 200 with the default message on a fresh instance (seed ran).
- [ ] `POST /status` / `DELETE /status` toggle status as before.
- [ ] Confirm no regression on older Harper versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)